### PR TITLE
Add static CNPJ alphanumeric generator page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gerador de CNPJ Alfanumérico (teste de desenvolvimento)</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Segoe UI", Roboto, sans-serif;
+      line-height: 1.5;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      background: #f7f7f7;
+      color: #222;
+    }
+
+    main {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem 1rem;
+    }
+
+    .container {
+      width: min(540px, 100%);
+      background: #fff;
+      border-radius: 12px;
+      padding: 2rem;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(1.5rem, 2vw + 1rem, 2.25rem);
+    }
+
+    .actions {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .resultado {
+      display: flex;
+      gap: 0.5rem;
+      align-items: stretch;
+      flex-wrap: wrap;
+    }
+
+    .resultado input {
+      flex: 1 1 240px;
+      padding: 0.75rem 1rem;
+      font-size: 1.125rem;
+      border: 1px solid #cdd3d8;
+      border-radius: 8px;
+      background: #fdfdfd;
+      color: inherit;
+    }
+
+    button {
+      border: none;
+      background: #2563eb;
+      color: #fff;
+      padding: 0.75rem 1.5rem;
+      border-radius: 999px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease, transform 0.1s ease;
+    }
+
+    button:hover {
+      background: #1d4ed8;
+    }
+
+    button:active {
+      transform: scale(0.98);
+    }
+
+    button:focus-visible {
+      outline: 3px solid #93c5fd;
+      outline-offset: 2px;
+    }
+
+    .botao-copiar {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 1rem;
+      min-width: 3rem;
+    }
+
+    .botao-copiar svg {
+      width: 1.25rem;
+      height: 1.25rem;
+      fill: currentColor;
+    }
+
+    .toast {
+      position: fixed;
+      right: 1rem;
+      bottom: 1rem;
+      min-width: 240px;
+      max-width: calc(100% - 2rem);
+      padding: 0.75rem 1rem;
+      border-radius: 8px;
+      background: rgba(15, 118, 110, 0.95);
+      color: #fff;
+      opacity: 0;
+      pointer-events: none;
+      transform: translateY(20px);
+      transition: opacity 0.2s ease, transform 0.2s ease;
+      font-size: 0.95rem;
+      box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+    }
+
+    .toast.visivel {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .toast.erro {
+      background: rgba(185, 28, 28, 0.95);
+    }
+
+    footer {
+      margin-top: auto;
+      background: #111827;
+      color: #e5e7eb;
+      padding: 1.5rem 1rem;
+    }
+
+    footer h2 {
+      margin: 0 0 0.75rem;
+      font-size: 1.125rem;
+    }
+
+    footer ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    footer a {
+      color: inherit;
+      text-decoration: none;
+      border-bottom: 1px dotted rgba(229, 231, 235, 0.6);
+    }
+
+    footer a:hover,
+    footer a:focus-visible {
+      text-decoration: underline;
+      color: #bfdbfe;
+    }
+
+    @media (max-width: 480px) {
+      .container {
+        padding: 1.5rem;
+      }
+
+      .botao-copiar {
+        flex: 1 1 100%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="container">
+      <h1>Gerador de CNPJ Alfanumérico (teste de desenvolvimento)</h1>
+      <div class="actions">
+        <button id="botao-gerar" type="button" aria-label="Gerar novo CNPJ alfanumérico">
+          Gerar CNPJ alfanumérico
+        </button>
+        <div class="resultado">
+          <input id="campo-resultado" type="text" readonly aria-label="CNPJ alfanumérico gerado">
+          <button id="botao-copiar" class="botao-copiar" type="button" aria-label="Copiar CNPJ alfanumérico">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M16 1H4a2 2 0 0 0-2 2v14h2V3h12z"></path>
+              <path d="M20 5H8a2 2 0 0 0-2 2v16h12a2 2 0 0 0 2-2V5zm-2 16H8V7h10z"></path>
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </main>
+  <footer>
+    <h2>Links úteis</h2>
+    <ul>
+      <li><a href="#">Receita Federal — CNPJ Alfanumérico (2026)</a></li>
+      <li><a href="#">Padrão de máscara e validação (interno)</a></li>
+      <li><a href="#">Spec técnica resumida</a></li>
+      <li><a href="https://github.com/FernandoBade/GeradorDeCNPJAlfanumerico">Link github</a></li>
+    </ul>
+  </footer>
+  <div id="toast" class="toast" role="status" aria-live="polite"></div>
+  <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,155 @@
+const CARACTERES_PERMITIDOS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const PESOS_DV1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+const PESOS_DV2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+const TAMANHO_CORPO = 12;
+const TAMANHO_TOTAL = 14;
+const DURACAO_TOAST_MS = 2500;
+let valorAtual = null;
+let timeoutToast;
+const campoResultadoElemento = document.getElementById("campo-resultado");
+const botaoGerarElemento = document.getElementById("botao-gerar");
+const botaoCopiarElemento = document.getElementById("botao-copiar");
+const toastElementoBase = document.getElementById("toast");
+if (!(campoResultadoElemento instanceof HTMLInputElement) ||
+    !(botaoGerarElemento instanceof HTMLButtonElement) ||
+    !(botaoCopiarElemento instanceof HTMLButtonElement) ||
+    !(toastElementoBase instanceof HTMLDivElement)) {
+    throw new Error("Elementos essenciais não encontrados na página.");
+}
+const campoResultado = campoResultadoElemento;
+const botaoGerar = botaoGerarElemento;
+const botaoCopiar = botaoCopiarElemento;
+const toastElemento = toastElementoBase;
+// Gera uma sequência aleatória de 12 caracteres permitidos.
+function gerarCorpoAlfanumerico() {
+    let corpo = "";
+    for (let i = 0; i < TAMANHO_CORPO; i += 1) {
+        const indice = Math.floor(Math.random() * CARACTERES_PERMITIDOS.length);
+        corpo += CARACTERES_PERMITIDOS[indice];
+    }
+    return corpo;
+}
+// Converte cada caractere da sequência em seu valor ASCII numérico.
+function converterParaASCII(corpo) {
+    return Array.from(corpo).map((caractere) => caractere.charCodeAt(0));
+}
+// Calcula um dígito verificador seguindo o módulo 11 com os pesos fornecidos.
+function calcularDigitoVerificador(valores, pesos) {
+    const soma = valores.reduce((acumulado, valor, indice) => acumulado + valor * pesos[indice], 0);
+    const resto = soma % 11;
+    return resto < 2 ? 0 : 11 - resto;
+}
+// Valida se todos os caracteres de uma sequência são iguais.
+function sequenciaRepetida(valor) {
+    return valor.split("").every((caractere) => caractere === valor[0]);
+}
+// Aplica a máscara ##.###.###/####-## convertendo letras para dígitos visuais.
+export function toMasked(valor) {
+    const numerosParaMascara = Array.from(valor).map((caractere) => {
+        return /\d/.test(caractere) ? caractere : String(caractere.charCodeAt(0) % 10);
+    });
+    const mascara = "##.###.###/####-##";
+    let indice = 0;
+    let resultado = "";
+    for (const simbolo of mascara) {
+        if (simbolo === "#") {
+            resultado += numerosParaMascara[indice] ?? "";
+            indice += 1;
+        }
+        else {
+            resultado += simbolo;
+        }
+    }
+    return resultado;
+}
+// Assegura regras básicas de sanidade da sequência final.
+function verificarSanidade(valor) {
+    if (valor.length !== TAMANHO_TOTAL) {
+        throw new Error("Identificador inválido: tamanho inesperado.");
+    }
+    const dv1 = valor[TAMANHO_TOTAL - 2];
+    const dv2 = valor[TAMANHO_TOTAL - 1];
+    if (!/\d/.test(dv1) || !/\d/.test(dv2)) {
+        throw new Error("Identificador inválido: dígitos verificadores não numéricos.");
+    }
+}
+// Gera um identificador completo com corpo + DV1 + DV2, evitando sequências repetidas.
+function gerarIdentificador() {
+    for (let tentativas = 0; tentativas < 1000; tentativas += 1) {
+        const corpo = gerarCorpoAlfanumerico();
+        const valoresASCII = converterParaASCII(corpo);
+        if (sequenciaRepetida(corpo)) {
+            continue;
+        }
+        const dv1 = calcularDigitoVerificador(valoresASCII, PESOS_DV1);
+        const dv2 = calcularDigitoVerificador([...valoresASCII, dv1], PESOS_DV2);
+        const completo = `${corpo}${dv1}${dv2}`;
+        if (sequenciaRepetida(completo)) {
+            continue;
+        }
+        verificarSanidade(completo);
+        return { valor: completo, mascarado: toMasked(completo) };
+    }
+    throw new Error("Não foi possível gerar um identificador válido após várias tentativas.");
+}
+// Copia o valor informado para a área de transferência.
+async function copiarParaClipboard(valor) {
+    await navigator.clipboard.writeText(valor);
+}
+// Exibe uma mensagem temporária de feedback ao usuário.
+function exibirToast(mensagem, tipo = "sucesso") {
+    toastElemento.textContent = mensagem;
+    toastElemento.classList.remove("erro", "visivel");
+    if (tipo === "erro") {
+        toastElemento.classList.add("erro");
+    }
+    requestAnimationFrame(() => {
+        toastElemento.classList.add("visivel");
+    });
+    if (timeoutToast !== undefined) {
+        window.clearTimeout(timeoutToast);
+    }
+    timeoutToast = window.setTimeout(() => {
+        toastElemento.classList.remove("visivel");
+    }, DURACAO_TOAST_MS);
+}
+// Remove o toast imediatamente (útil ao gerar um novo valor).
+function ocultarToast() {
+    toastElemento.classList.remove("visivel", "erro");
+    if (timeoutToast !== undefined) {
+        window.clearTimeout(timeoutToast);
+    }
+}
+// Evento principal do botão Gerar.
+botaoGerar.addEventListener("click", () => {
+    try {
+        const { valor, mascarado } = gerarIdentificador();
+        valorAtual = valor;
+        campoResultado.value = mascarado;
+        ocultarToast();
+    }
+    catch (erro) {
+        const mensagem = erro instanceof Error ? erro.message : "Erro inesperado ao gerar.";
+        valorAtual = null;
+        campoResultado.value = "";
+        exibirToast(mensagem, "erro");
+    }
+});
+// Evento do botão Copiar.
+botaoCopiar.addEventListener("click", async () => {
+    if (!valorAtual) {
+        exibirToast("Nenhum CNPJ gerado para copiar.", "erro");
+        return;
+    }
+    try {
+        await copiarParaClipboard(valorAtual);
+        exibirToast(`CNPJ copiado: ${valorAtual}`);
+    }
+    catch (erro) {
+        const mensagem = erro instanceof Error ? erro.message : "Falha ao copiar.";
+        exibirToast(mensagem, "erro");
+    }
+});
+// Exemplos rápidos:
+// gerarCorpoAlfanumerico() -> "0AB3..." (12 caracteres)
+// toMasked("ABC12345678901") -> "56.712.345/6789-01"

--- a/main.ts
+++ b/main.ts
@@ -1,0 +1,180 @@
+const CARACTERES_PERMITIDOS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const PESOS_DV1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+const PESOS_DV2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+const TAMANHO_CORPO = 12;
+const TAMANHO_TOTAL = 14;
+const DURACAO_TOAST_MS = 2500;
+
+let valorAtual: string | null = null;
+let timeoutToast: number | undefined;
+
+const campoResultadoElemento = document.getElementById("campo-resultado");
+const botaoGerarElemento = document.getElementById("botao-gerar");
+const botaoCopiarElemento = document.getElementById("botao-copiar");
+const toastElementoBase = document.getElementById("toast");
+
+if (
+  !(campoResultadoElemento instanceof HTMLInputElement) ||
+  !(botaoGerarElemento instanceof HTMLButtonElement) ||
+  !(botaoCopiarElemento instanceof HTMLButtonElement) ||
+  !(toastElementoBase instanceof HTMLDivElement)
+) {
+  throw new Error("Elementos essenciais não encontrados na página.");
+}
+
+const campoResultado = campoResultadoElemento;
+const botaoGerar = botaoGerarElemento;
+const botaoCopiar = botaoCopiarElemento;
+const toastElemento = toastElementoBase;
+
+// Gera uma sequência aleatória de 12 caracteres permitidos.
+function gerarCorpoAlfanumerico(): string {
+  let corpo = "";
+  for (let i = 0; i < TAMANHO_CORPO; i += 1) {
+    const indice = Math.floor(Math.random() * CARACTERES_PERMITIDOS.length);
+    corpo += CARACTERES_PERMITIDOS[indice];
+  }
+  return corpo;
+}
+
+// Converte cada caractere da sequência em seu valor ASCII numérico.
+function converterParaASCII(corpo: string): number[] {
+  return Array.from(corpo).map((caractere) => caractere.charCodeAt(0));
+}
+
+// Calcula um dígito verificador seguindo o módulo 11 com os pesos fornecidos.
+function calcularDigitoVerificador(valores: number[], pesos: number[]): number {
+  const soma = valores.reduce((acumulado, valor, indice) => acumulado + valor * pesos[indice], 0);
+  const resto = soma % 11;
+  return resto < 2 ? 0 : 11 - resto;
+}
+
+// Valida se todos os caracteres de uma sequência são iguais.
+function sequenciaRepetida(valor: string): boolean {
+  return valor.split("").every((caractere) => caractere === valor[0]);
+}
+
+// Aplica a máscara ##.###.###/####-## convertendo letras para dígitos visuais.
+export function toMasked(valor: string): string {
+  const numerosParaMascara = Array.from(valor).map((caractere) => {
+    return /\d/.test(caractere) ? caractere : String(caractere.charCodeAt(0) % 10);
+  });
+  const mascara = "##.###.###/####-##";
+  let indice = 0;
+  let resultado = "";
+
+  for (const simbolo of mascara) {
+    if (simbolo === "#") {
+      resultado += numerosParaMascara[indice] ?? "";
+      indice += 1;
+    } else {
+      resultado += simbolo;
+    }
+  }
+
+  return resultado;
+}
+
+// Assegura regras básicas de sanidade da sequência final.
+function verificarSanidade(valor: string): void {
+  if (valor.length !== TAMANHO_TOTAL) {
+    throw new Error("Identificador inválido: tamanho inesperado.");
+  }
+  const dv1 = valor[TAMANHO_TOTAL - 2];
+  const dv2 = valor[TAMANHO_TOTAL - 1];
+  if (!/\d/.test(dv1) || !/\d/.test(dv2)) {
+    throw new Error("Identificador inválido: dígitos verificadores não numéricos.");
+  }
+}
+
+// Gera um identificador completo com corpo + DV1 + DV2, evitando sequências repetidas.
+function gerarIdentificador(): { valor: string; mascarado: string } {
+  for (let tentativas = 0; tentativas < 1000; tentativas += 1) {
+    const corpo = gerarCorpoAlfanumerico();
+    const valoresASCII = converterParaASCII(corpo);
+
+    if (sequenciaRepetida(corpo)) {
+      continue;
+    }
+
+    const dv1 = calcularDigitoVerificador(valoresASCII, PESOS_DV1);
+    const dv2 = calcularDigitoVerificador([...valoresASCII, dv1], PESOS_DV2);
+
+    const completo = `${corpo}${dv1}${dv2}`;
+
+    if (sequenciaRepetida(completo)) {
+      continue;
+    }
+
+    verificarSanidade(completo);
+    return { valor: completo, mascarado: toMasked(completo) };
+  }
+
+  throw new Error("Não foi possível gerar um identificador válido após várias tentativas.");
+}
+
+// Copia o valor informado para a área de transferência.
+async function copiarParaClipboard(valor: string): Promise<void> {
+  await navigator.clipboard.writeText(valor);
+}
+
+// Exibe uma mensagem temporária de feedback ao usuário.
+function exibirToast(mensagem: string, tipo: "sucesso" | "erro" = "sucesso"): void {
+  toastElemento.textContent = mensagem;
+  toastElemento.classList.remove("erro", "visivel");
+  if (tipo === "erro") {
+    toastElemento.classList.add("erro");
+  }
+  requestAnimationFrame(() => {
+    toastElemento.classList.add("visivel");
+  });
+  if (timeoutToast !== undefined) {
+    window.clearTimeout(timeoutToast);
+  }
+  timeoutToast = window.setTimeout(() => {
+    toastElemento.classList.remove("visivel");
+  }, DURACAO_TOAST_MS);
+}
+
+// Remove o toast imediatamente (útil ao gerar um novo valor).
+function ocultarToast(): void {
+  toastElemento.classList.remove("visivel", "erro");
+  if (timeoutToast !== undefined) {
+    window.clearTimeout(timeoutToast);
+  }
+}
+
+// Evento principal do botão Gerar.
+botaoGerar.addEventListener("click", () => {
+  try {
+    const { valor, mascarado } = gerarIdentificador();
+    valorAtual = valor;
+    campoResultado.value = mascarado;
+    ocultarToast();
+  } catch (erro) {
+    const mensagem = erro instanceof Error ? erro.message : "Erro inesperado ao gerar.";
+    valorAtual = null;
+    campoResultado.value = "";
+    exibirToast(mensagem, "erro");
+  }
+});
+
+// Evento do botão Copiar.
+botaoCopiar.addEventListener("click", async () => {
+  if (!valorAtual) {
+    exibirToast("Nenhum CNPJ gerado para copiar.", "erro");
+    return;
+  }
+
+  try {
+    await copiarParaClipboard(valorAtual);
+    exibirToast(`CNPJ copiado: ${valorAtual}`);
+  } catch (erro) {
+    const mensagem = erro instanceof Error ? erro.message : "Falha ao copiar.";
+    exibirToast(mensagem, "erro");
+  }
+});
+
+// Exemplos rápidos:
+// gerarCorpoAlfanumerico() -> "0AB3..." (12 caracteres)
+// toMasked("ABC12345678901") -> "56.712.345/6789-01"


### PR DESCRIPTION
## Summary
- add a responsive static page with controls to gerar and copiar o CNPJ alfanumérico and inline styling
- implement TypeScript logic for generating corpo e dígitos verificadores, mascarar valores e exibir toasts, com compilação para main.js

## Testing
- npx tsc main.ts --target ES2020 --module ES2020 --outDir .

------
https://chatgpt.com/codex/tasks/task_b_68dda0062e60832bba4cb8a0b6b94fe6