### PR TITLE
Refatora gerador para TypeScript tipado

### DIFF
--- a/constantes.ts
+++ b/constantes.ts
@@ -1,0 +1,46 @@
+/* ============================
+   Constantes do Gerador CNPJ Alfanumérico 2026
+============================ */
+
+import { ClasseAviso, TipoAviso } from "./enums";
+import { PesosDigitos } from "./tipos";
+
+/**
+ * @summary Caracteres elegíveis para compor o corpo alfanumérico do identificador.
+ */
+export const CARACTERES_PERMITIDOS: string = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+/**
+ * @summary Pesos do módulo 11 aplicados aos dígitos verificadores.
+ */
+export const PESOS_DIGITOS: PesosDigitos = {
+    primeiro: [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2],
+    segundo: [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2],
+};
+
+/**
+ * @summary Representa a combinação de classes CSS utilizadas por tipo de aviso.
+ */
+export const MAPA_CLASSES_TIPO_AVISO: Record<TipoAviso, string[]> = {
+    [TipoAviso.Sucesso]: [ClasseAviso.FundoSucesso, ClasseAviso.TextoBranco],
+    [TipoAviso.Info]: [ClasseAviso.FundoInfo, ClasseAviso.TextoBranco],
+    [TipoAviso.Erro]: [ClasseAviso.FundoErro, ClasseAviso.TextoBranco],
+};
+
+/**
+ * @summary Classes aplicadas ao iniciar o aviso em estado oculto.
+ */
+export const CLASSES_AVISO_OCULTO: string[] = [
+    ClasseAviso.OpacidadeOculta,
+    ClasseAviso.TranslacaoOculta,
+    ClasseAviso.PonteiroDesativado,
+];
+
+/**
+ * @summary Classes utilizadas quando o aviso está visível.
+ */
+export const CLASSES_AVISO_VISIVEL: string[] = [
+    ClasseAviso.OpacidadeVisivel,
+    ClasseAviso.TranslacaoVisivel,
+    ClasseAviso.PonteiroAtivo,
+];

--- a/enums.ts
+++ b/enums.ts
@@ -1,0 +1,45 @@
+/* ============================
+   Definições de enums para o Gerador CNPJ Alfanumérico 2026
+============================ */
+
+/**
+ * @summary Possíveis tamanhos do identificador alfanumérico.
+ */
+export enum TamanhoIdentificador {
+    Corpo = 12,
+    Total = 14,
+}
+
+/**
+ * @summary Durações e intervalos utilizados pelos temporizadores da interface.
+ */
+export enum IntervaloTemporizador {
+    GeracaoAutomatica = 10_000,
+    Atualizacao = 100,
+    Aviso = 2_500,
+}
+
+/**
+ * @summary Classes utilitárias aplicadas ao componente de aviso.
+ */
+export enum ClasseAviso {
+    OpacidadeOculta = "opacity-0",
+    TranslacaoOculta = "translate-y-5",
+    OpacidadeVisivel = "opacity-100",
+    TranslacaoVisivel = "translate-y-0",
+    FundoSucesso = "bg-emerald-600",
+    FundoErro = "bg-red-600",
+    FundoInfo = "bg-blue-600",
+    TextoBranco = "text-white",
+    PonteiroDesativado = "pointer-events-none",
+    PonteiroAtivo = "pointer-events-auto",
+}
+
+/**
+ * @summary Identifica os tipos de aviso exibidos ao usuário.
+ */
+export enum TipoAviso {
+    Sucesso = "sucesso",
+    Info = "info",
+    Erro = "erro",
+}

--- a/tipos.ts
+++ b/tipos.ts
@@ -1,0 +1,51 @@
+/* ============================
+   Tipos e interfaces do Gerador CNPJ Alfanumérico 2026
+============================ */
+
+/**
+ * @summary Estrutura com os pesos utilizados no cálculo dos dígitos verificadores.
+ */
+export interface PesosDigitos {
+    primeiro: number[];
+    segundo: number[];
+}
+
+/**
+ * @summary Limites e dados relacionados ao histórico de identificadores.
+ */
+export interface HistoricoIdentificadores {
+    itens: string[];
+    limite: number;
+}
+
+/**
+ * @summary Estrutura com referências a todos os elementos de interface utilizados.
+ */
+export interface ElementosInterface {
+    campoResultado: HTMLInputElement;
+    botaoGerar: HTMLButtonElement;
+    botaoCopiar: HTMLButtonElement;
+    areaAviso: HTMLDivElement;
+    textoTempoRestante: HTMLDivElement;
+    barraProgresso: HTMLElement;
+    controleMascara: HTMLInputElement | null;
+    listaRecentes: HTMLUListElement | null;
+    botaoCopiarTodos: HTMLButtonElement | null;
+}
+
+/**
+ * @summary Representa um identificador gerado pelo algoritmo.
+ */
+export interface IdentificadorGerado {
+    puro: string;
+    mascarado: string;
+}
+
+/**
+ * @summary Estrutura de controle dos temporizadores utilizados na interface.
+ */
+export interface Temporizadores {
+    timeoutAviso?: number;
+    intervaloRegressivo?: number;
+    inicioContagem: number;
+}


### PR DESCRIPTION
## Summary
- reorganiza o gerador em uma classe `GeradorCnpj` com tipagem explícita e comentários JSDoc
- adiciona enums, interfaces e tipos auxiliares para os avisos, temporizadores e histórico
- garante tipagem estrita dos elementos da interface e dos fluxos de cópia e histórico
- distribui enums, tipos e constantes em módulos TypeScript dedicados para facilitar manutenção

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68deb8d9293c832b99e91a1ce02eb072