### PR TITLE
Add explanatory guide and validator pages for alphanumeric CNPJ

### DIFF
--- a/dist/paginas/validador.js
+++ b/dist/paginas/validador.js
@@ -1,0 +1,222 @@
+import { ClasseAviso, IntervaloTemporizador, TipoAviso, } from "../src/enums.js";
+import { CLASSES_AVISO_OCULTO, CLASSES_AVISO_VISIVEL, MAPA_CLASSES_TIPO_AVISO, PESOS_DIGITOS, } from "../src/constantes.js";
+import { htmlCookies, inicializarAvisoDeCookies } from "../src/cookies.js";
+class ValidadorCnpj {
+    constructor(elementos) {
+        this.elementos = elementos;
+        this.historico = [];
+        this.limiteHistorico = 100;
+        this.configurarEventos();
+        this.alternarModoMassa(false);
+    }
+    configurarEventos() {
+        const { botaoValidarUnico, botaoValidarMassa, controleMascara, controleMassa, botaoColar, } = this.elementos;
+        botaoValidarUnico.addEventListener("click", () => {
+            this.validarUnico();
+        });
+        botaoValidarMassa.addEventListener("click", () => {
+            this.validarEmMassa();
+        });
+        controleMascara.addEventListener("change", () => {
+            this.renderizarHistorico();
+        });
+        controleMassa.addEventListener("change", () => {
+            this.alternarModoMassa(controleMassa.checked);
+        });
+        botaoColar.addEventListener("click", async () => {
+            await this.colarDoClipboard();
+        });
+    }
+    alternarModoMassa(ativo) {
+        const { campoUnico, campoMassa, botaoValidarUnico, botaoValidarMassa, botaoColar, } = this.elementos;
+        campoUnico.classList.toggle("hidden", ativo);
+        campoMassa.classList.toggle("hidden", !ativo);
+        botaoValidarUnico.classList.toggle("hidden", ativo);
+        botaoValidarMassa.classList.toggle("hidden", !ativo);
+        botaoColar.classList.toggle("hidden", ativo);
+        if (ativo) {
+            campoMassa.value = "";
+            campoMassa.focus();
+        }
+        else {
+            campoUnico.focus();
+        }
+    }
+    async colarDoClipboard() {
+        try {
+            const texto = await navigator.clipboard.readText();
+            if (!texto) {
+                this.exibirAviso("Nenhum conteúdo disponível para colar", TipoAviso.Erro);
+                return;
+            }
+            this.elementos.campoUnico.value = texto.trim();
+            this.exibirAviso("Conteúdo colado", TipoAviso.Info);
+        }
+        catch {
+            this.exibirAviso("Não foi possível acessar a área de transferência", TipoAviso.Erro);
+        }
+    }
+    validarUnico() {
+        const valor = this.elementos.campoUnico.value.trim();
+        if (!valor) {
+            this.exibirAviso("Informe um CNPJ para validar", TipoAviso.Erro);
+            return;
+        }
+        const resultado = this.validarCnpj(valor);
+        this.adicionarAoHistorico(resultado);
+        this.renderizarHistorico();
+        if (resultado.valido) {
+            this.exibirAviso("CNPJ válido", TipoAviso.Sucesso);
+        }
+        else {
+            this.exibirAviso("CNPJ inválido", TipoAviso.Erro);
+        }
+    }
+    validarEmMassa() {
+        const valor = this.elementos.campoMassa.value.trim();
+        if (!valor) {
+            this.exibirAviso("Informe ao menos um CNPJ para validar", TipoAviso.Erro);
+            return;
+        }
+        const entradas = valor
+            .split(",")
+            .map((parte) => parte.trim())
+            .filter((parte) => parte.length > 0);
+        if (entradas.length === 0) {
+            this.exibirAviso("Informe ao menos um CNPJ para validar", TipoAviso.Erro);
+            return;
+        }
+        if (entradas.length > 100) {
+            this.exibirAviso("Limite de 100 CNPJs por validação", TipoAviso.Erro);
+            return;
+        }
+        let validos = 0;
+        let invalidos = 0;
+        entradas.forEach((entrada) => {
+            const resultado = this.validarCnpj(entrada);
+            if (resultado.valido) {
+                validos++;
+            }
+            else {
+                invalidos++;
+            }
+            this.adicionarAoHistorico(resultado);
+        });
+        this.renderizarHistorico();
+        if (invalidos === 0 && validos > 0) {
+            this.exibirAviso("CNPJ válido", TipoAviso.Sucesso);
+        }
+        else {
+            this.exibirAviso("CNPJ inválido", TipoAviso.Erro);
+        }
+    }
+    adicionarAoHistorico(resultado) {
+        this.historico.unshift(resultado);
+        if (this.historico.length > this.limiteHistorico) {
+            this.historico.length = this.limiteHistorico;
+        }
+    }
+    renderizarHistorico() {
+        const { listaHistorico, controleMascara } = this.elementos;
+        listaHistorico.innerHTML = "";
+        const aplicarMascara = controleMascara.checked;
+        this.historico.forEach((item) => {
+            const elemento = document.createElement("li");
+            elemento.className =
+                "flex items-center justify-between gap-3 rounded-xl bg-zinc-50/60 dark:bg-slate-900/60 px-3 py-2";
+            const texto = document.createElement("span");
+            texto.className = "text-sm font-semibold text-slate-600 dark:text-zinc-50 break-words";
+            texto.textContent = this.formatarParaExibicao(item.puro, aplicarMascara);
+            const status = document.createElement("span");
+            status.className = item.valido
+                ? "inline-flex items-center gap-2 rounded-full bg-emerald-500/90 px-3 py-1 text-xs font-semibold text-white"
+                : "inline-flex items-center gap-2 rounded-full bg-red-500/90 px-3 py-1 text-xs font-semibold text-white";
+            status.textContent = item.valido ? "✅ Válido" : "❌ Inválido";
+            elemento.append(texto, status);
+            listaHistorico.appendChild(elemento);
+        });
+        listaHistorico.scrollTop = 0;
+    }
+    formatarParaExibicao(cnpj, aplicarMascara) {
+        if (!aplicarMascara || cnpj.length !== 14) {
+            return cnpj;
+        }
+        return `${cnpj.slice(0, 2)}.${cnpj.slice(2, 5)}.${cnpj.slice(5, 8)}/${cnpj.slice(8, 12)}-${cnpj.slice(12)}`;
+    }
+    validarCnpj(entrada) {
+        const normalizado = entrada.toUpperCase();
+        const possuiCaracteresInvalidos = /[^0-9A-Z.\-/\s]/.test(normalizado);
+        const puro = normalizado.replace(/[.\-/\s]/g, "");
+        if (possuiCaracteresInvalidos) {
+            return { puro, valido: false };
+        }
+        if (puro.length !== 14) {
+            return { puro, valido: false };
+        }
+        if (!/^[0-9A-Z]{12}[0-9]{2}$/.test(puro)) {
+            return { puro, valido: false };
+        }
+        if (/^([0-9A-Z])\1{13}$/.test(puro)) {
+            return { puro, valido: false };
+        }
+        const corpo = puro.slice(0, 12);
+        const dvInformado = puro.slice(12);
+        const valores = Array.from(corpo).map((caractere) => this.converterCaractere(caractere));
+        const primeiroDV = this.calcularDigito(valores, PESOS_DIGITOS.primeiro);
+        const segundoDV = this.calcularDigito([...valores, primeiroDV], PESOS_DIGITOS.segundo);
+        const valido = primeiroDV === Number.parseInt(dvInformado[0] ?? "", 10)
+            && segundoDV === Number.parseInt(dvInformado[1] ?? "", 10);
+        return { puro, valido };
+    }
+    converterCaractere(caractere) {
+        const codigo = caractere.charCodeAt(0);
+        return codigo - 48;
+    }
+    calcularDigito(valores, pesos) {
+        const soma = valores.reduce((acumulado, valorAtual, indice) => acumulado + valorAtual * (pesos[indice] ?? 0), 0);
+        const resto = soma % 11;
+        return resto < 2 ? 0 : 11 - resto;
+    }
+    exibirAviso(mensagem, tipo) {
+        const { areaAviso } = this.elementos;
+        const classesBase = "fixed bottom-4 right-4 min-w-[240px] max-w-[calc(100%-2rem)] rounded-lg px-4 py-3 text-sm shadow-2xl transition-all duration-200 ease-out";
+        areaAviso.textContent = mensagem;
+        areaAviso.className = `${classesBase} ${MAPA_CLASSES_TIPO_AVISO[tipo].join(" ")} ${ClasseAviso.OpacidadeOculta} ${ClasseAviso.TranslacaoOculta} ${ClasseAviso.PonteiroDesativado}`;
+        requestAnimationFrame(() => {
+            areaAviso.classList.remove(...CLASSES_AVISO_OCULTO);
+            areaAviso.classList.add(...CLASSES_AVISO_VISIVEL);
+        });
+        if (this.timeoutAviso !== undefined) {
+            window.clearTimeout(this.timeoutAviso);
+        }
+        this.timeoutAviso = window.setTimeout(() => {
+            areaAviso.classList.remove(...CLASSES_AVISO_VISIVEL);
+            areaAviso.classList.add(...CLASSES_AVISO_OCULTO);
+        }, IntervaloTemporizador.Aviso);
+    }
+}
+function obterElementoObrigatorio(id) {
+    const elemento = document.getElementById(id);
+    if (!elemento) {
+        throw new Error(`Elemento com id "${id}" não encontrado.`);
+    }
+    return elemento;
+}
+document.addEventListener("DOMContentLoaded", () => {
+    if (!document.getElementById("aviso-cookies")) {
+        document.body.insertAdjacentHTML("beforeend", htmlCookies);
+    }
+    inicializarAvisoDeCookies();
+    const elementos = {
+        campoUnico: obterElementoObrigatorio("campo-unico"),
+        campoMassa: obterElementoObrigatorio("campo-massa"),
+        controleMascara: obterElementoObrigatorio("toggle-mascara-validator"),
+        controleMassa: obterElementoObrigatorio("toggle-massa"),
+        botaoValidarUnico: obterElementoObrigatorio("botao-validar"),
+        botaoValidarMassa: obterElementoObrigatorio("botao-validar-massa"),
+        listaHistorico: obterElementoObrigatorio("lista-historico-validacao"),
+        areaAviso: obterElementoObrigatorio("toast"),
+        botaoColar: obterElementoObrigatorio("botao-colar"),
+    };
+    void new ValidadorCnpj(elementos);
+});

--- a/paginas/como-a-validacao-de-cnpj-e-feita.html
+++ b/paginas/como-a-validacao-de-cnpj-e-feita.html
@@ -1,0 +1,478 @@
+<!doctype html>
+<html lang="pt-BR">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>Como a validação do CNPJ alfanumérico é feita? | CNPJ 2026</title>
+    <meta name="description"
+        content="Entenda, passo a passo, como o cálculo dos dígitos verificadores do CNPJ alfanumérico é realizado seguindo o manual oficial do SERPRO." />
+    <meta name="robots" content="index, follow" />
+    <meta name="language" content="pt-BR" />
+
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="manifest" href="/site.webmanifest">
+    <meta name="theme-color" content="#2563eb" />
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+        };
+    </script>
+    <link rel="stylesheet" href="../src/estilos/controle-tema.css" />
+</head>
+
+<body
+    class="min-h-screen bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-zinc-50 transition-colors duration-500 font-sans flex flex-col">
+
+    <main class="flex-1 flex items-center justify-center px-4 py-6">
+        <div class="flex flex-col gap-6 items-stretch w-full max-w-6xl">
+            <div class="flex justify-end">
+                <label for="alternar-tema"
+                    class="controle-tema inline-flex items-center gap-3 rounded-2xl bg-zinc-50 dark:bg-slate-800 px-4 py-2 shadow-md backdrop-blur">
+                    <span class="flex items-center gap-1 text-sm font-medium text-slate-800 dark:text-zinc-50">Tema</span>
+                    <input id="alternar-tema" type="checkbox" class="sr-only" />
+                    <div
+                        class="trilha cursor-pointer relative flex h-8 w-16 items-center shadow-inner dark:shadow-inner dark:shadow-slate-900 rounded-full dark:bg-slate-800 px-1 transition-colors duration-300">
+                        <span
+                            class="sol-indicador absolute ml-0.5 text-zinc-800 hover:scale-110 transition-all ease-in-out">
+                            <svg class="w-6 h-6 text-orange-300 dark:text-zinc-50 transition-all dark:hover:scale-110 duration-300 ease-in-out"
+                                aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                fill="currentColor" viewBox="0 0 24 24">
+                                <path fill-rule="evenodd"
+                                    d="M13 3a1 1 0 1 0-2 0v2a1 1 0 1 0 2 0V3ZM6.343 4.929A1 1 0 0 0 4.93 6.343l1.414 1.414a1 1 0 0 0 1.414-1.414L6.343 4.929Zm12.728 1.414a1 1 0 0 0-1.414-1.414l-1.414 1.414a1 1 0 0 0 1.414 1.414l1.414-1.414ZM12 7a5 5 0 1 0 0 10 5 5 0 0 0 0-10Zm-9 4a1 1 0 1 0 0 2h2a1 1 0 1 0 0-2H3Zm16 0a1 1 0 1 0 0 2h2a1 1 0 1 0 0-2h-2ZM7.757 17.657a1 1 0 1 0-1.414-1.414l-1.414 1.414a1 1 0 1 0 1.414 1.414l1.414-1.414Zm9.9-1.414a1 1 0 0 0-1.414 1.414l1.414 1.414a1 1 0 0 0 1.414-1.414l-1.414-1.414ZM13 19a1 1 0 1 0-2 0v2a1 1 0 1 0 2 0v-2Z"
+                                    clip-rule="evenodd" />
+                            </svg>
+                        </span>
+                        <span
+                            class="lua-indicador absolute right-2 text-violet-500 hover:scale-115 dark:hover:scale-110 transition-all ease-in-out">
+                            <svg class="w-6 h-6 text-zinc-400 dark:text-sky-600 transition-all hover:scale-110 duration-300 ease-in-out"
+                                aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                fill="currentColor" viewBox="0 0 24 24">
+                                <path fill-rule="evenodd"
+                                    d="M17 4c.5523 0 1 .44772 1 1v2h2c.5523 0 1 .44771 1 1 0 .55228-.4477 1-1 1h-2v2c0 .5523-.4477 1-1 1s-1-.4477-1-1V9h-2c-.5523 0-1-.44772-1-1s.4477-1 1-1h2V5c0-.55228.4477-1 1-1Z"
+                                    clip-rule="evenodd" />
+                                <path
+                                    d="M12.3224 4.68708c.2935-.31028.3575-.77266.1594-1.15098-.1981-.37832-.6146-.5891-1.0368-.52467-1.50847.2302-2.93175.83665-4.12869 1.76276-1.19717.92628-2.12732 2.1411-2.69465 3.52702-.56744 1.38618-.75115 2.89299-.53164 4.37079.2195 1.4776.83393 2.8711 1.77895 4.0436.9448 1.1722 2.18683 2.0826 3.60103 2.6449 1.414.5623 2.9539.7584 4.4683.57 1.5145-.1884 2.9549-.7551 4.1784-1.6475 1.2237-.8924 2.1892-2.0806 2.7972-3.4499.1723-.3879.0809-.8423-.2279-1.1335-.3089-.2911-.7679-.3556-1.145-.1608-.8631.4459-1.8291.6799-2.8118.6791h-.0018c-1.1598.0013-2.2925-.3234-3.2596-.931-.9667-.6074-1.7244-1.4697-2.1856-2.4779-.4611-1.00776-.6079-2.1209-.4243-3.20511.1835-1.08442.6905-2.09837 1.4645-2.91681Z" />
+                            </svg>
+                        </span>
+                        <span class="botao"></span>
+                    </div>
+                </label>
+            </div>
+
+            <section
+                class="w-full bg-zinc-50 dark:bg-slate-800 rounded-3xl shadow-2xl p-8 transition-colors duration-500 flex flex-col gap-6">
+                <div class="text-center space-y-3">
+                    <p class="text-sm uppercase tracking-[0.35em] text-violet-500 font-semibold">Guia didático</p>
+                    <h1 class="text-3xl md:text-4xl font-bold text-slate-700 dark:text-zinc-50">
+                        Como a validação do CNPJ alfanumérico é feita?
+                    </h1>
+                    <p class="text-base text-slate-600 dark:text-slate-400 max-w-3xl mx-auto">
+                        O manual “Cálculo dos dígitos verificadores de CNPJ alfanumérico”, publicado pelo SERPRO, descreve um
+                        processo em duas etapas para garantir que cada identificador tenha uma estrutura matemática válida. A
+                        seguir, mostramos esse passo a passo com a mesma linguagem visual do nosso gerador.
+                    </p>
+                </div>
+
+                <div class="grid gap-5 md:grid-cols-3">
+                    <article
+                        class="bg-white/80 dark:bg-slate-900/60 border border-slate-200/40 dark:border-slate-700/60 rounded-2xl p-6 flex flex-col gap-4">
+                        <header class="space-y-1">
+                            <h2 class="text-xl font-semibold text-slate-700 dark:text-zinc-50">Estrutura do CNPJ</h2>
+                            <p class="text-sm text-slate-500 dark:text-slate-400">
+                                12 caracteres alfanuméricos + 2 dígitos verificadores (numéricos).
+                            </p>
+                        </header>
+                        <p class="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                            A Receita Federal adota o padrão “Corpo + DV”. Os 12 primeiros caracteres podem ser números ou letras
+                            maiúsculas (0-9, A-Z). Os dois últimos são os dígitos verificadores, calculados pelo módulo 11. Qualquer
+                            CNPJ com tamanho diferente ou caracteres fora desse conjunto é matematicamente inválido.
+                        </p>
+                    </article>
+
+                    <article
+                        class="bg-white/80 dark:bg-slate-900/60 border border-slate-200/40 dark:border-slate-700/60 rounded-2xl p-6 flex flex-col gap-4">
+                        <header class="space-y-1">
+                            <h2 class="text-xl font-semibold text-slate-700 dark:text-zinc-50">Peso e módulo 11</h2>
+                            <p class="text-sm text-slate-500 dark:text-slate-400">
+                                Pesos de 2 a 9 aplicados da direita para a esquerda.
+                            </p>
+                        </header>
+                        <p class="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                            Para o 1º DV usamos os pesos 5,4,3,2,9,8,7,6,5,4,3,2. Para o 2º DV, o corpo recebe os pesos 6 a 2 e o
+                            primeiro DV calculado completa a sequência. Depois de multiplicar cada caractere pelo peso
+                            correspondente, somamos tudo e aplicamos <span class="font-semibold text-violet-500">módulo 11</span>.
+                            Se o resto for 0 ou 1, o DV vira 0. Caso contrário, usamos <code class="font-mono">11 - resto</code>.
+                        </p>
+                    </article>
+
+                    <article
+                        class="bg-white/80 dark:bg-slate-900/60 border border-slate-200/40 dark:border-slate-700/60 rounded-2xl p-6 flex flex-col gap-4">
+                        <header class="space-y-1">
+                            <h2 class="text-xl font-semibold text-slate-700 dark:text-zinc-50">Conversão ASCII</h2>
+                            <p class="text-sm text-slate-500 dark:text-slate-400">Valor para cálculo = ASCII - 48.</p>
+                        </header>
+                        <p class="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                            Cada caractere recebe um valor numérico conforme a tabela do SERPRO. Basta subtrair 48 do código ASCII:
+                            <strong>0</strong> (48) vale 0, <strong>A</strong> (65) vira 17, <strong>Z</strong> (90) vira 42. É esse
+                            número que participa da multiplicação pelos pesos para formar o somatório do módulo 11.
+                        </p>
+                    </article>
+                </div>
+
+                <section class="grid gap-5 md:grid-cols-2">
+                    <article
+                        class="bg-white/90 dark:bg-slate-900/60 border border-slate-200/40 dark:border-slate-700/60 rounded-2xl p-6 flex flex-col gap-4">
+                        <header class="space-y-1">
+                            <h3 class="text-xl font-semibold text-slate-700 dark:text-zinc-50">Etapas do cálculo do DV</h3>
+                        </header>
+                        <ol class="list-decimal list-inside space-y-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                            <li>
+                                Converta os 12 caracteres iniciais para valores numéricos (ASCII - 48).
+                            </li>
+                            <li>
+                                Multiplique cada valor pelo peso indicado para o primeiro DV (5 a 2 e depois 9 a 2).
+                            </li>
+                            <li>
+                                Some todos os resultados e aplique módulo 11. Se o resto for menor que 2, o DV é 0. Caso contrário,
+                                <code class="font-mono">11 - resto</code> fornece o valor.
+                            </li>
+                            <li>
+                                Acrescente o primeiro DV ao final do corpo e repita o processo com os pesos do segundo DV (6 a 2 e
+                                depois 9 a 2).
+                            </li>
+                            <li>
+                                Compare os dois dígitos obtidos com os dígitos informados no CNPJ. Se ambos coincidirem, o número é
+                                matematicamente válido.
+                            </li>
+                        </ol>
+                    </article>
+
+                    <article
+                        class="bg-white/90 dark:bg-slate-900/60 border border-slate-200/40 dark:border-slate-700/60 rounded-2xl p-6 flex flex-col gap-4">
+                        <header class="space-y-1">
+                            <h3 class="text-xl font-semibold text-slate-700 dark:text-zinc-50">Exemplo prático</h3>
+                            <p class="text-sm text-slate-500 dark:text-slate-400">Referência do manual oficial (páginas 3 e 4).</p>
+                        </header>
+                        <p class="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                            CNPJ base: <code class="font-mono text-violet-500">12ABC34501DE</code>
+                        </p>
+                        <p class="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                            Valores (ASCII - 48): <span class="font-mono">1 2 17 18 19 3 4 5 0 1 20 21</span>
+                        </p>
+                        <p class="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                            Pesos 1º DV: <span class="font-mono">5 4 3 2 9 8 7 6 5 4 3 2</span> → Somatório 459 → Resto 8 →
+                            <strong>1º DV = 3</strong>
+                        </p>
+                        <p class="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                            Pesos 2º DV: <span class="font-mono">6 5 4 3 2 9 8 7 6 5 4 3 2</span> → Somatório 424 → Resto 6 →
+                            <strong>2º DV = 5</strong>
+                        </p>
+                        <p class="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                            Resultado final: <code class="font-mono text-violet-500">12.ABC.345/01DE-35</code>
+                        </p>
+                    </article>
+                </section>
+
+                <article
+                    class="bg-white/95 dark:bg-slate-900/60 border border-slate-200/40 dark:border-slate-700/60 rounded-2xl p-6 flex flex-col gap-4">
+                    <h3 class="text-xl font-semibold text-slate-700 dark:text-zinc-50">CNPJ válido x CNPJ ativo</h3>
+                    <p class="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                        Um CNPJ pode ser <strong>matematicamente válido</strong> (estrutura correta e dígitos verificadores
+                        compatíveis) e ainda assim não existir na base da Receita Federal ou estar baixado/suspenso. A validação do
+                        nosso gerador confirma formato, possíveis combinações e integridade dos dígitos verificadores — mas não
+                        substitui consultas oficiais de situação cadastral.
+                    </p>
+                </article>
+
+                <article
+                    class="bg-white/95 dark:bg-slate-900/60 border border-slate-200/40 dark:border-slate-700/60 rounded-2xl p-6 flex flex-col gap-4">
+                    <h3 class="text-xl font-semibold text-slate-700 dark:text-zinc-50">Tabela resumida — ASCII → Valor para o DV</h3>
+                    <p class="text-sm text-slate-600 dark:text-slate-300">
+                        Baseada na tabela oficial do SERPRO. Subtraia 48 do código ASCII para encontrar o valor usado no cálculo do
+                        módulo 11.
+                    </p>
+                    <div class="overflow-x-auto rounded-2xl border border-slate-200/40 dark:border-slate-700/60">
+                        <table class="min-w-full divide-y divide-slate-200 dark:divide-slate-700 text-sm">
+                            <thead class="bg-slate-100/80 dark:bg-slate-800/80 text-slate-600 dark:text-slate-300">
+                                <tr>
+                                    <th scope="col" class="px-3 py-2 text-left font-semibold">Caractere</th>
+                                    <th scope="col" class="px-3 py-2 text-left font-semibold">ASCII</th>
+                                    <th scope="col" class="px-3 py-2 text-left font-semibold">Valor para o DV</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100 dark:divide-slate-800 text-slate-600 dark:text-slate-300">
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">0</td>
+                                    <td class="px-3 py-2 font-mono">48</td>
+                                    <td class="px-3 py-2 font-mono">0</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">1</td>
+                                    <td class="px-3 py-2 font-mono">49</td>
+                                    <td class="px-3 py-2 font-mono">1</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">2</td>
+                                    <td class="px-3 py-2 font-mono">50</td>
+                                    <td class="px-3 py-2 font-mono">2</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">3</td>
+                                    <td class="px-3 py-2 font-mono">51</td>
+                                    <td class="px-3 py-2 font-mono">3</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">4</td>
+                                    <td class="px-3 py-2 font-mono">52</td>
+                                    <td class="px-3 py-2 font-mono">4</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">5</td>
+                                    <td class="px-3 py-2 font-mono">53</td>
+                                    <td class="px-3 py-2 font-mono">5</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">6</td>
+                                    <td class="px-3 py-2 font-mono">54</td>
+                                    <td class="px-3 py-2 font-mono">6</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">7</td>
+                                    <td class="px-3 py-2 font-mono">55</td>
+                                    <td class="px-3 py-2 font-mono">7</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">8</td>
+                                    <td class="px-3 py-2 font-mono">56</td>
+                                    <td class="px-3 py-2 font-mono">8</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">9</td>
+                                    <td class="px-3 py-2 font-mono">57</td>
+                                    <td class="px-3 py-2 font-mono">9</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">A</td>
+                                    <td class="px-3 py-2 font-mono">65</td>
+                                    <td class="px-3 py-2 font-mono">17</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">B</td>
+                                    <td class="px-3 py-2 font-mono">66</td>
+                                    <td class="px-3 py-2 font-mono">18</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">C</td>
+                                    <td class="px-3 py-2 font-mono">67</td>
+                                    <td class="px-3 py-2 font-mono">19</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">D</td>
+                                    <td class="px-3 py-2 font-mono">68</td>
+                                    <td class="px-3 py-2 font-mono">20</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">E</td>
+                                    <td class="px-3 py-2 font-mono">69</td>
+                                    <td class="px-3 py-2 font-mono">21</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">F</td>
+                                    <td class="px-3 py-2 font-mono">70</td>
+                                    <td class="px-3 py-2 font-mono">22</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">G</td>
+                                    <td class="px-3 py-2 font-mono">71</td>
+                                    <td class="px-3 py-2 font-mono">23</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">H</td>
+                                    <td class="px-3 py-2 font-mono">72</td>
+                                    <td class="px-3 py-2 font-mono">24</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">I</td>
+                                    <td class="px-3 py-2 font-mono">73</td>
+                                    <td class="px-3 py-2 font-mono">25</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">J</td>
+                                    <td class="px-3 py-2 font-mono">74</td>
+                                    <td class="px-3 py-2 font-mono">26</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">K</td>
+                                    <td class="px-3 py-2 font-mono">75</td>
+                                    <td class="px-3 py-2 font-mono">27</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">L</td>
+                                    <td class="px-3 py-2 font-mono">76</td>
+                                    <td class="px-3 py-2 font-mono">28</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">M</td>
+                                    <td class="px-3 py-2 font-mono">77</td>
+                                    <td class="px-3 py-2 font-mono">29</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">N</td>
+                                    <td class="px-3 py-2 font-mono">78</td>
+                                    <td class="px-3 py-2 font-mono">30</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">O</td>
+                                    <td class="px-3 py-2 font-mono">79</td>
+                                    <td class="px-3 py-2 font-mono">31</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">P</td>
+                                    <td class="px-3 py-2 font-mono">80</td>
+                                    <td class="px-3 py-2 font-mono">32</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">Q</td>
+                                    <td class="px-3 py-2 font-mono">81</td>
+                                    <td class="px-3 py-2 font-mono">33</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">R</td>
+                                    <td class="px-3 py-2 font-mono">82</td>
+                                    <td class="px-3 py-2 font-mono">34</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">S</td>
+                                    <td class="px-3 py-2 font-mono">83</td>
+                                    <td class="px-3 py-2 font-mono">35</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">T</td>
+                                    <td class="px-3 py-2 font-mono">84</td>
+                                    <td class="px-3 py-2 font-mono">36</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">U</td>
+                                    <td class="px-3 py-2 font-mono">85</td>
+                                    <td class="px-3 py-2 font-mono">37</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">V</td>
+                                    <td class="px-3 py-2 font-mono">86</td>
+                                    <td class="px-3 py-2 font-mono">38</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">W</td>
+                                    <td class="px-3 py-2 font-mono">87</td>
+                                    <td class="px-3 py-2 font-mono">39</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">X</td>
+                                    <td class="px-3 py-2 font-mono">88</td>
+                                    <td class="px-3 py-2 font-mono">40</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">Y</td>
+                                    <td class="px-3 py-2 font-mono">89</td>
+                                    <td class="px-3 py-2 font-mono">41</td>
+                                </tr>
+                                <tr class="bg-white/70 dark:bg-slate-900/40">
+                                    <td class="px-3 py-2 font-mono">Z</td>
+                                    <td class="px-3 py-2 font-mono">90</td>
+                                    <td class="px-3 py-2 font-mono">42</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </article>
+            </section>
+        </div>
+    </main>
+
+    <footer
+        class="mt-2 bg-slate-900 dark:bg-slate-900 px-6 py-6 text-slate-200 dark:text-zinc-50 transition-colors duration-500">
+        <div class="mx-auto flex w-full max-w-4xl flex-col gap-8">
+            <div class="flex flex-row justify-between gap-2 text-sm text-slate-100 dark:text-slate-500 px-6 md:px-28">
+                <h2 class="text-xl font-semibold flex items-center gap-2">🔗 Links</h2>
+                <ul class="grid gap-3 text-sm">
+                    <li>
+                        <a href="https://www.gov.br/receitafederal/pt-br/acesso-a-informacao/acoes-e-programas/programas-e-atividades/cnpj-alfanumerico"
+                            class="flex items-center gap-2 pb-0.5 text-slate-300 dark:text-zinc-50 transition-colors hover:text-violet-500 dark:hover:text-violet-500 focus-visible:text-violet-500 dark:focus-visible:text-violet-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300"
+                            target="_blank">
+                            <svg class="w-6 h-6 text-slate-600" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
+                                width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+                                <path fill-rule="evenodd"
+                                    d="M5 3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11.5c.07 0 .14-.007.207-.021.095.014.193.021.293.021h2a2 2 0 0 0 2-2V7a1 1 0 0 0-1-1h-1a1 1 0 1 0 0 2v11h-2V5a2 2 0 0 0-2-2H5Zm7 4a1 1 0 0 1 1-1h.5a1 1 0 1 1 0 2H13a1 1 0 0 1-1-1Zm0 3a1 1 0 0 1 1-1h.5a1 1 0 1 1 0 2H13a1 1 0 0 1-1-1Zm-6 4a1 1 0 0 1 1-1h6a1 1 0 1 1 0 2H7a1 1 0 0 1-1-1Zm0 3a1 1 0 0 1 1-1h6a1 1 0 1 1 0 2H7a1 1 0 0 1-1-1ZM7 6a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H7Zm1 3V8h1v1H8Z"
+                                    clip-rule="evenodd" />
+                            </svg>
+                            Receita Federal — CNPJ Alfanumérico (2026)
+                        </a>
+                    </li>
+                    <li>
+                        <a href="https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/publicacoes/documentos-tecnicos/cnpj/manual-dv-cnpj.pdf/view"
+                            class="flex items-center gap-2 pb-0.5 text-slate-200 dark:text-zinc-50 transition-colors hover:text-violet-500 dark:hover:text-violet-500 focus-visible:text-violet-500 dark:focus-visible:text-violet-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300"
+                            target="_blank">
+                            <svg class="w-6 h-6 text-slate-600" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
+                                width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+                                <path fill-rule="evenodd"
+                                    d="M9 2.221V7H4.221a2 2 0 0 1 .365-.5L8.5 2.586A2 2 0 0 1 9 2.22ZM11 2v5a2 2 0 0 1-2 2H4a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2 2 2 0 0 0 2 2h12a2 2 0 0 0 2-2 2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2V4a2 2 0 0 0-2-2h-7Zm-6 9a1 1 0 0 0-1 1v5a1 1 0 1 0 2 0v-1h.5a2.5 2.5 0 0 0 0-5H5Zm1.5 3H6v-1h.5a.5.5 0 0 1 0 1Zm4.5-3a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h1.376A2.626 2.626 0 0 0 15 15.375v-1.75A2.626 2.626 0 0 0 12.375 11H11Zm1 5v-3h.375a.626.626 0 0 1 .625.626v1.748a.625.625 0 0 1-.626.626H12Zm5-5a1 1 0 0 0-1 1v5a1 1 0 1 0 2 0v-1h1a1 1 0 1 0 0-2h-1v-1h1a1 1 0 1 0 0-2h-2Z"
+                                    clip-rule="evenodd" />
+                            </svg>
+                            Manual de cálculo do DV do CNPJ
+                        </a>
+                    </li>
+                </ul>
+                <ul class="grid gap-3 text-sm">
+                    <li>
+                        <a href="https://github.com/FernandoBade/GeradorDeCNPJAlfanumerico"
+                            class="flex items-center gap-2 pb-0.5 text-slate-200 dark:text-zinc-50 transition-colors hover:text-violet-500 dark:hover:text-violet-500 focus-visible:text-violet-500 dark:focus-visible:text-violet-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300"
+                            target="_blank">
+                            <svg class="w-6 h-6 text-slate-600" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
+                                width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+                                <path fill-rule="evenodd"
+                                    d="M12.006 2a9.847 9.847 0 0 0-6.484 2.44 10.32 10.32 0 0 0-3.393 6.17 10.48 10.48 0 0 0 1.317 6.955 10.045 10.045 0 0 0 5.4 4.418c.504.095.683-.223.683-.494 0-.245-.01-1.052-.014-1.908-2.78.62-3.366-1.21-3.366-1.21a2.711 2.711 0 0 0-1.11-1.5c-.907-.637.07-.621.07-.621.317.044.62.163.885.346.266.183.487.426.647.71.135.253.318.476.538.655a2.079 2.079 0 0 0 2.37.196c.045-.52.27-1.006.635-1.37-2.219-.259-4.554-1.138-4.554-5.07a4.022 4.022 0 0 1 1.031-2.75 3.77 3.77 0 0 1 .096-2.713s.839-.275 2.749 1.05a9.26 9.26 0 0 1 5.004 0c1.906-1.325 2.74-1.05 2.74-1.05.37.858.406 1.828.101 2.713a4.017 4.017 0 0 1 1.029 2.75c0 3.939-2.339 4.805-4.564 5.058a2.471 2.471 0 0 1 .679 1.897c0 1.372-.012 2.477-.012 2.814 0 .272.18.592.687.492a10.05 10.05 0 0 0 5.388-4.421 10.473 10.473 0 0 0 1.313-6.948 10.32 10.32 0 0 0-3.39-6.165A9.847 9.847 0 0 0 12.007 2Z"
+                                    clip-rule="evenodd" />
+                            </svg>
+                            Repositório no GitHub
+                        </a>
+                    </li>
+                    <li>
+                        <a href="https://linkedin.com/in/fernandobade"
+                            class="flex items-center gap-2 pb-0.5 text-slate-200 dark:text-zinc-50 transition-colors hover:text-violet-500 dark:hover:text-violet-500 focus-visible:text-violet-500 dark:focus-visible:text-violet-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300"
+                            target="_blank">
+                            <svg class="w-6 h-6 text-slate-600" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
+                                width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+                                <path fill-rule="evenodd"
+                                    d="M12.51 8.796v1.697a3.738 3.738 0 0 1 3.288-1.684c3.455 0 4.202 2.16 4.202 4.97V19.5h-3.2v-5.072c0-1.21-.244-2.766-2.128-2.766-1.827 0-2.139 1.317-2.139 2.676V19.5h-3.19V8.796h3.168ZM7.2 6.106a1.61 1.61 0 0 1-.988 1.483 1.595 1.595 0 0 1-1.743-.348A1.607 1.607 0 0 1 5.6 4.5a1.601 1.601 0 0 1 1.6 1.606Z"
+                                    clip-rule="evenodd" />
+                                <path d="M7.2 8.809H4V19.5h3.2V8.809Z" />
+                            </svg>
+                            LinkedIn
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </footer>
+
+    <div id="toast"
+        class="fixed bottom-4 right-4 min-w-[240px] max-w-[calc(100%-2rem)] rounded-lg px-4 py-3 text-sm shadow-2xl transition-all duration-200 ease-out opacity-0 translate-y-5 pointer-events-none">
+    </div>
+
+    <script type="module" src="../dist/src/tema.js"></script>
+    <script type="module">
+        import { htmlCookies, inicializarAvisoDeCookies } from "../dist/src/cookies.js";
+        if (!document.getElementById("aviso-cookies")) {
+            document.body.insertAdjacentHTML("beforeend", htmlCookies);
+        }
+        inicializarAvisoDeCookies();
+    </script>
+</body>
+
+</html>

--- a/paginas/validador-de-cnpj-numerico.html
+++ b/paginas/validador-de-cnpj-numerico.html
@@ -1,0 +1,232 @@
+<!doctype html>
+<html lang="pt-BR">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>Validador de CNPJ Alfanumérico | Novo padrão 2026</title>
+    <meta name="description"
+        content="Valide CNPJs alfanuméricos individuais ou em massa, com suporte a máscara e histórico de resultados."
+    />
+    <meta name="robots" content="index, follow" />
+    <meta name="language" content="pt-BR" />
+
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="manifest" href="/site.webmanifest">
+    <meta name="theme-color" content="#2563eb" />
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+        };
+    </script>
+    <link rel="stylesheet" href="../src/estilos/controle-tema.css" />
+</head>
+
+<body
+    class="min-h-screen bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-zinc-50 transition-colors duration-500 font-sans flex flex-col">
+
+    <main class="flex-1 flex items-center justify-center px-4 py-6">
+        <div class="flex flex-col gap-6 items-stretch">
+            <div class="flex justify-end">
+                <label for="alternar-tema"
+                    class="controle-tema inline-flex items-center gap-3 rounded-2xl bg-zinc-50 dark:bg-slate-800 px-4 py-2 shadow-md backdrop-blur">
+                    <span class="flex items-center gap-1 text-sm font-medium text-slate-800 dark:text-zinc-50">Tema</span>
+                    <input id="alternar-tema" type="checkbox" class="sr-only" />
+                    <div
+                        class="trilha cursor-pointer relative flex h-8 w-16 items-center shadow-inner dark:shadow-inner dark:shadow-slate-900 rounded-full dark:bg-slate-800 px-1 transition-colors duration-300">
+                        <span
+                            class="sol-indicador absolute ml-0.5 text-zinc-800 hover:scale-110 transition-all ease-in-out">
+                            <svg class="w-6 h-6 text-orange-300 dark:text-zinc-50 transition-all dark:hover:scale-110 duration-300 ease-in-out"
+                                aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                fill="currentColor" viewBox="0 0 24 24">
+                                <path fill-rule="evenodd"
+                                    d="M13 3a1 1 0 1 0-2 0v2a1 1 0 1 0 2 0V3ZM6.343 4.929A1 1 0 0 0 4.93 6.343l1.414 1.414a1 1 0 0 0 1.414-1.414L6.343 4.929Zm12.728 1.414a1 1 0 0 0-1.414-1.414l-1.414 1.414a1 1 0 0 0 1.414 1.414l1.414-1.414ZM12 7a5 5 0 1 0 0 10 5 5 0 0 0 0-10Zm-9 4a1 1 0 1 0 0 2h2a1 1 0 1 0 0-2H3Zm16 0a1 1 0 1 0 0 2h2a1 1 0 1 0 0-2h-2ZM7.757 17.657a1 1 0 1 0-1.414-1.414l-1.414 1.414a1 1 0 1 0 1.414 1.414l1.414-1.414Zm9.9-1.414a1 1 0 0 0-1.414 1.414l1.414 1.414a1 1 0 0 0 1.414-1.414l-1.414-1.414ZM13 19a1 1 0 1 0-2 0v2a1 1 0 1 0 2 0v-2Z"
+                                    clip-rule="evenodd" />
+                            </svg>
+                        </span>
+                        <span
+                            class="lua-indicador absolute right-2 text-violet-500 hover:scale-115 dark:hover:scale-110 transition-all ease-in-out">
+                            <svg class="w-6 h-6 text-zinc-400 dark:text-sky-600 transition-all hover:scale-110 duration-300 ease-in-out"
+                                aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                fill="currentColor" viewBox="0 0 24 24">
+                                <path fill-rule="evenodd"
+                                    d="M17 4c.5523 0 1 .44772 1 1v2h2c.5523 0 1 .44771 1 1 0 .55228-.4477 1-1 1h-2v2c0 .5523-.4477 1-1 1s-1-.4477-1-1V9h-2c-.5523 0-1-.44772-1-1s.4477-1 1-1h2V5c0-.55228.4477-1 1-1Z"
+                                    clip-rule="evenodd" />
+                                <path
+                                    d="M12.3224 4.68708c.2935-.31028.3575-.77266.1594-1.15098-.1981-.37832-.6146-.5891-1.0368-.52467-1.50847.2302-2.93175.83665-4.12869 1.76276-1.19717.92628-2.12732 2.1411-2.69465 3.52702-.56744 1.38618-.75115 2.89299-.53164 4.37079.2195 1.4776.83393 2.8711 1.77895 4.0436.9448 1.1722 2.18683 2.0826 3.60103 2.6449 1.414.5623 2.9539.7584 4.4683.57 1.5145-.1884 2.9549-.7551 4.1784-1.6475 1.2237-.8924 2.1892-2.0806 2.7972-3.4499.1723-.3879.0809-.8423-.2279-1.1335-.3089-.2911-.7679-.3556-1.145-.1608-.8631.4459-1.8291.6799-2.8118.6791h-.0018c-1.1598.0013-2.2925-.3234-3.2596-.931-.9667-.6074-1.7244-1.4697-2.1856-2.4779-.4611-1.00776-.6079-2.1209-.4243-3.20511.1835-1.08442.6905-2.09837 1.4645-2.91681Z" />
+                            </svg>
+                        </span>
+                        <span class="botao"></span>
+                    </div>
+                </label>
+            </div>
+
+            <div class="flex flex-col md:flex-row gap-6 items-stretch">
+                <div
+                    class="w-full max-w-lg bg-zinc-50 dark:bg-slate-800 rounded-3xl shadow-2xl p-6 flex flex-col self-stretch transition-colors duration-500">
+                    <div class="flex flex-col gap-1 text-center">
+                        <h1 class="mt-4 text-3xl font-bold text-slate-600 dark:text-zinc-50">
+                            Validador de CNPJ Alfanumérico
+                        </h1>
+                        <p class="text-sm text-slate-500 dark:text-slate-400">
+                            Verifique combinações individuais ou lote com o mesmo visual do gerador.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-col gap-6 max-w-lg mx-auto w-full">
+                        <div class="flex flex-wrap items-stretch mt-6 gap-1">
+                            <div class="relative flex-1 min-w-[240px]">
+                                <input id="campo-unico" type="text" autocomplete="off"
+                                    class="w-full rounded-lg text-slate-600 dark:text-zinc-50 text-center border-slate-300 dark:border-slate-600 bg-zinc-50 dark:bg-slate-900 px-3 pr-12 py-2 text-lg font-semibold shadow-inner focus:outline-none focus:ring-2 focus:ring-violet-300 dark:focus:ring-violet-500 transition-colors duration-300"
+                                    placeholder="Informe o CNPJ" />
+                                <textarea id="campo-massa"
+                                    class="hidden w-full min-h-[140px] rounded-lg text-slate-600 dark:text-zinc-50 text-left border-slate-300 dark:border-slate-600 bg-zinc-50 dark:bg-slate-900 px-3 py-3 text-sm font-medium shadow-inner focus:outline-none focus:ring-2 focus:ring-violet-300 dark:focus:ring-violet-500 transition-colors duration-300 resize-y"
+                                    placeholder="Cole até 100 CNPJs separados por vírgula"></textarea>
+                                <button id="botao-colar" type="button" title="Colar da área de transferência"
+                                    class="absolute right-2 top-1/2 -translate-y-1/2 inline-flex items-center justify-center rounded text-violet-500 dark:text-violet-500 transition-all ease-in-out hover:text-violet-500 dark:hover:text-violet-500 hover:scale-110 px-2 py-1"
+                                    aria-label="Colar conteúdo">
+                                    <svg class="w-8 h-8" aria-hidden="true" fill="none" viewBox="0 0 24 24">
+                                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                                            stroke-width="1.5"
+                                            d="M8 3h8m-6 3h4m-6 0a2 2 0 1 1-2-2m2 2a2 2 0 1 0 2-2m-2 2v.667c0 .934 0 1.4.109 1.756a2 2 0 0 0 1.401 1.401C11.866 10 12.333 10 13.266 10H15.6c.56 0 .84 0 1.054.109.19.098.343.252.44.441.109.214.109.494.109 1.054V19a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2v-8.396c0-.56 0-.84.109-1.054.097-.19.252-.343.44-.44C6.763 9 7.043 9 7.604 9H8" />
+                                    </svg>
+                                </button>
+                            </div>
+                            <p class="w-full text-xs text-slate-500 dark:text-slate-400 text-center">
+                                Aceita entradas com ou sem máscara. A validação usa o cálculo oficial do SERPRO.
+                            </p>
+                        </div>
+
+                        <div class="flex flex-col items-center gap-5 mt-2 text-sm text-slate-600 dark:text-slate-500">
+                            <div class="flex flex-col sm:flex-row gap-4">
+                                <label for="toggle-mascara-validator"
+                                    class="inline-flex cursor-pointer items-center gap-3 text-sm font-medium text-slate-600 dark:text-zinc-50 select-none">
+                                    <input id="toggle-mascara-validator" type="checkbox" class="sr-only peer" checked />
+                                    <div
+                                        class="relative h-6 w-11 rounded-full bg-slate-500 dark:bg-slate-500 transition-colors duration-300 peer-checked:bg-violet-500 hover:peer-checked:bg-violet-600 dark:hover:peer-checked:bg-violet-600 dark:peer-checked:bg-violet-500 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:h-5 after:w-5 after:rounded-full after:bg-zinc-50 after:shadow after:transition-transform after:duration-300 peer-checked:after:translate-x-5">
+                                    </div>
+                                    <span class="transition-colors duration-300 peer-checked:font-semibold">Exibir com máscara</span>
+                                </label>
+
+                                <label for="toggle-massa"
+                                    class="inline-flex cursor-pointer items-center gap-3 text-sm font-medium text-slate-600 dark:text-zinc-50 select-none">
+                                    <input id="toggle-massa" type="checkbox" class="sr-only peer" />
+                                    <div
+                                        class="relative h-6 w-11 rounded-full bg-slate-500 dark:bg-slate-500 transition-colors duration-300 peer-checked:bg-violet-500 hover:peer-checked:bg-violet-600 dark:hover:peer-checked:bg-violet-600 dark:peer-checked:bg-violet-500 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:h-5 after:w-5 after:rounded-full after:bg-zinc-50 after:shadow after:transition-transform after:duration-300 peer-checked:after:translate-x-5">
+                                    </div>
+                                    <span class="transition-colors duration-300 peer-checked:font-semibold">Validação em massa</span>
+                                </label>
+                            </div>
+
+                            <div class="flex w-[340px] mt-[12px] gap-4">
+                                <button id="botao-validar" type="button"
+                                    class="flex-1 inline-flex items-center justify-center rounded-lg bg-transparent border border-violet-500 px-1 py-2 text-base font-semibold text-violet-500 shadow-sm transition-all ease-in-out duration-300 dark:text-violet-300 dark:border-violet-400 hover:border-violet-600 hover:text-violet-500 hover:shadow-md dark:hover:shadow-md dark:hover:border-violet-500 dark:hover:text-violet-500 focus:outline-none focus:ring-2 focus:ring-violet-300 dark:focus:ring-violet-500 active:scale-95">
+                                    Validar CNPJ
+                                </button>
+                                <button id="botao-validar-massa" type="button"
+                                    class="hidden flex-1 inline-flex items-center justify-center rounded-lg bg-violet-500 dark:bg-violet-500 px-1 py-2 text-base font-semibold text-zinc-50 shadow-sm transition-all ease-in-out duration-300 hover:bg-violet-600 dark:hover:bg-violet-600 focus:outline-none hover:shadow-md dark:hover:shadow-md focus:ring-2 focus:ring-slate-300 dark:focus:ring-violet-500 active:scale-95">
+                                    Validar CNPJs em Massa
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div id="painel-validacao" class="w-full md:w-80 flex flex-col self-stretch min-h-0 h-[380px]">
+                    <div
+                        class="bg-zinc-50 dark:bg-slate-800 rounded-3xl shadow-2xl dark:shadow-2xl py-2 px-4 flex-1 flex flex-col h-full min-h-0 max-h-[420px] overflow-hidden transition-colors duration-500">
+                        <h2 class="font-bold text-lg text-center text-slate-800 dark:text-zinc-50 pt-7 pb-4">
+                            Histórico de validações
+                        </h2>
+                        <ul id="lista-historico-validacao"
+                            class="scroll-personalizado space-y-2 ml-2 pr-2 py-3 px-2 text-sm text-slate-600 dark:text-slate-500 flex-1 overflow-y-auto shadow-inner rounded-lg">
+                        </ul>
+                        <p class="text-xs text-center text-slate-500 dark:text-slate-400 pb-6">
+                            Mantemos até 100 registros recentes com o status ✅ Válido ou ❌ Inválido.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <footer
+        class="mt-2 bg-slate-900 dark:bg-slate-900 px-6 py-6 text-slate-200 dark:text-zinc-50 transition-colors duration-500">
+        <div class="mx-auto flex w-full max-w-4xl flex-col gap-8">
+            <div class="flex flex-row justify-between gap-2 text-sm text-slate-100 dark:text-slate-500 px-6 md:px-28">
+                <h2 class="text-xl font-semibold flex items-center gap-2">🔗 Links</h2>
+                <ul class="grid gap-3 text-sm">
+                    <li>
+                        <a href="https://www.gov.br/receitafederal/pt-br/acesso-a-informacao/acoes-e-programas/programas-e-atividades/cnpj-alfanumerico"
+                            class="flex items-center gap-2 pb-0.5 text-slate-300 dark:text-zinc-50 transition-colors hover:text-violet-500 dark:hover:text-violet-500 focus-visible:text-violet-500 dark:focus-visible:text-violet-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300"
+                            target="_blank">
+                            <svg class="w-6 h-6 text-slate-600" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
+                                width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+                                <path fill-rule="evenodd"
+                                    d="M5 3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11.5c.07 0 .14-.007.207-.021.095.014.193.021.293.021h2a2 2 0 0 0 2-2V7a1 1 0 0 0-1-1h-1a1 1 0 1 0 0 2v11h-2V5a2 2 0 0 0-2-2H5Zm7 4a1 1 0 0 1 1-1h.5a1 1 0 1 1 0 2H13a1 1 0 0 1-1-1Zm0 3a1 1 0 0 1 1-1h.5a1 1 0 1 1 0 2H13a1 1 0 0 1-1-1Zm-6 4a1 1 0 0 1 1-1h6a1 1 0 1 1 0 2H7a1 1 0 0 1-1-1Zm0 3a1 1 0 0 1 1-1h6a1 1 0 1 1 0 2H7a1 1 0 0 1-1-1ZM7 6a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H7Zm1 3V8h1v1H8Z"
+                                    clip-rule="evenodd" />
+                            </svg>
+                            Receita Federal — CNPJ Alfanumérico (2026)
+                        </a>
+                    </li>
+                    <li>
+                        <a href="https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/publicacoes/documentos-tecnicos/cnpj/manual-dv-cnpj.pdf/view"
+                            class="flex items-center gap-2 pb-0.5 text-slate-200 dark:text-zinc-50 transition-colors hover:text-violet-500 dark:hover:text-violet-500 focus-visible:text-violet-500 dark:focus-visible:text-violet-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300"
+                            target="_blank">
+                            <svg class="w-6 h-6 text-slate-600" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
+                                width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+                                <path fill-rule="evenodd"
+                                    d="M9 2.221V7H4.221a2 2 0 0 1 .365-.5L8.5 2.586A2 2 0 0 1 9 2.22ZM11 2v5a2 2 0 0 1-2 2H4a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2 2 2 0 0 0 2 2h12a2 2 0 0 0 2-2 2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2V4a2 2 0 0 0-2-2h-7Zm-6 9a1 1 0 0 0-1 1v5a1 1 0 1 0 2 0v-1h.5a2.5 2.5 0 0 0 0-5H5Zm1.5 3H6v-1h.5a.5.5 0 0 1 0 1Zm4.5-3a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h1.376A2.626 2.626 0 0 0 15 15.375v-1.75A2.626 2.626 0 0 0 12.375 11H11Zm1 5v-3h.375a.626.626 0 0 1 .625.626v1.748a.625.625 0 0 1-.626.626H12Zm5-5a1 1 0 0 0-1 1v5a1 1 0 1 0 2 0v-1h1a1 1 0 1 0 0-2h-1v-1h1a1 1 0 1 0 0-2h-2Z"
+                                    clip-rule="evenodd" />
+                            </svg>
+                            Manual de cálculo do DV do CNPJ
+                        </a>
+                    </li>
+                </ul>
+                <ul class="grid gap-3 text-sm">
+                    <li>
+                        <a href="https://github.com/FernandoBade/GeradorDeCNPJAlfanumerico"
+                            class="flex items-center gap-2 pb-0.5 text-slate-200 dark:text-zinc-50 transition-colors hover:text-violet-500 dark:hover:text-violet-500 focus-visible:text-violet-500 dark:focus-visible:text-violet-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300"
+                            target="_blank">
+                            <svg class="w-6 h-6 text-slate-600" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
+                                width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+                                <path fill-rule="evenodd"
+                                    d="M12.006 2a9.847 9.847 0 0 0-6.484 2.44 10.32 10.32 0 0 0-3.393 6.17 10.48 10.48 0 0 0 1.317 6.955 10.045 10.045 0 0 0 5.4 4.418c.504.095.683-.223.683-.494 0-.245-.01-1.052-.014-1.908-2.78.62-3.366-1.21-3.366-1.21a2.711 2.711 0 0 0-1.11-1.5c-.907-.637.07-.621.07-.621.317.044.62.163.885.346.266.183.487.426.647.71.135.253.318.476.538.655a2.079 2.079 0 0 0 2.37.196c.045-.52.27-1.006.635-1.37-2.219-.259-4.554-1.138-4.554-5.07a4.022 4.022 0 0 1 1.031-2.75 3.77 3.77 0 0 1 .096-2.713s.839-.275 2.749 1.05a9.26 9.26 0 0 1 5.004 0c1.906-1.325 2.74-1.05 2.74-1.05.37.858.406 1.828.101 2.713a4.017 4.017 0 0 1 1.029 2.75c0 3.939-2.339 4.805-4.564 5.058a2.471 2.471 0 0 1 .679 1.897c0 1.372-.012 2.477-.012 2.814 0 .272.18.592.687.492a10.05 10.05 0 0 0 5.388-4.421 10.473 10.473 0 0 0 1.313-6.948 10.32 10.32 0 0 0-3.39-6.165A9.847 9.847 0 0 0 12.007 2Z"
+                                    clip-rule="evenodd" />
+                            </svg>
+                            Repositório no GitHub
+                        </a>
+                    </li>
+                    <li>
+                        <a href="https://linkedin.com/in/fernandobade"
+                            class="flex items-center gap-2 pb-0.5 text-slate-200 dark:text-zinc-50 transition-colors hover:text-violet-500 dark:hover:text-violet-500 focus-visible:text-violet-500 dark:focus-visible:text-violet-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300"
+                            target="_blank">
+                            <svg class="w-6 h-6 text-slate-600" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
+                                width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+                                <path fill-rule="evenodd"
+                                    d="M12.51 8.796v1.697a3.738 3.738 0 0 1 3.288-1.684c3.455 0 4.202 2.16 4.202 4.97V19.5h-3.2v-5.072c0-1.21-.244-2.766-2.128-2.766-1.827 0-2.139 1.317-2.139 2.676V19.5h-3.19V8.796h3.168ZM7.2 6.106a1.61 1.61 0 0 1-.988 1.483 1.595 1.595 0 0 1-1.743-.348A1.607 1.607 0 0 1 5.6 4.5a1.601 1.601 0 0 1 1.6 1.606Z"
+                                    clip-rule="evenodd" />
+                                <path d="M7.2 8.809H4V19.5h3.2V8.809Z" />
+                            </svg>
+                            LinkedIn
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </footer>
+
+    <div id="toast"
+        class="fixed bottom-4 right-4 min-w-[240px] max-w-[calc(100%-2rem)] rounded-lg px-4 py-3 text-sm shadow-2xl transition-all duration-200 ease-out opacity-0 translate-y-5 pointer-events-none">
+    </div>
+
+    <script type="module" src="../dist/src/tema.js"></script>
+    <script type="module" src="../dist/paginas/validador.js"></script>
+</body>
+
+</html>

--- a/paginas/validador.ts
+++ b/paginas/validador.ts
@@ -1,0 +1,311 @@
+import {
+    ClasseAviso,
+    IntervaloTemporizador,
+    TipoAviso,
+} from "../src/enums.js";
+import {
+    CLASSES_AVISO_OCULTO,
+    CLASSES_AVISO_VISIVEL,
+    MAPA_CLASSES_TIPO_AVISO,
+    PESOS_DIGITOS,
+} from "../src/constantes.js";
+import { htmlCookies, inicializarAvisoDeCookies } from "../src/cookies.js";
+
+interface ElementosValidador {
+    campoUnico: HTMLInputElement;
+    campoMassa: HTMLTextAreaElement;
+    controleMascara: HTMLInputElement;
+    controleMassa: HTMLInputElement;
+    botaoValidarUnico: HTMLButtonElement;
+    botaoValidarMassa: HTMLButtonElement;
+    listaHistorico: HTMLUListElement;
+    areaAviso: HTMLDivElement;
+    botaoColar: HTMLButtonElement;
+}
+
+interface ResultadoValidacao {
+    puro: string;
+    valido: boolean;
+}
+
+class ValidadorCnpj {
+    private readonly historico: ResultadoValidacao[] = [];
+    private readonly limiteHistorico = 100;
+    private timeoutAviso?: number;
+
+    public constructor(private readonly elementos: ElementosValidador) {
+        this.configurarEventos();
+        this.alternarModoMassa(false);
+    }
+
+    private configurarEventos(): void {
+        const {
+            botaoValidarUnico,
+            botaoValidarMassa,
+            controleMascara,
+            controleMassa,
+            botaoColar,
+        } = this.elementos;
+
+        botaoValidarUnico.addEventListener("click", () => {
+            this.validarUnico();
+        });
+
+        botaoValidarMassa.addEventListener("click", () => {
+            this.validarEmMassa();
+        });
+
+        controleMascara.addEventListener("change", () => {
+            this.renderizarHistorico();
+        });
+
+        controleMassa.addEventListener("change", () => {
+            this.alternarModoMassa(controleMassa.checked);
+        });
+
+        botaoColar.addEventListener("click", async () => {
+            await this.colarDoClipboard();
+        });
+    }
+
+    private alternarModoMassa(ativo: boolean): void {
+        const {
+            campoUnico,
+            campoMassa,
+            botaoValidarUnico,
+            botaoValidarMassa,
+            botaoColar,
+        } = this.elementos;
+
+        campoUnico.classList.toggle("hidden", ativo);
+        campoMassa.classList.toggle("hidden", !ativo);
+        botaoValidarUnico.classList.toggle("hidden", ativo);
+        botaoValidarMassa.classList.toggle("hidden", !ativo);
+        botaoColar.classList.toggle("hidden", ativo);
+
+        if (ativo) {
+            campoMassa.value = "";
+            campoMassa.focus();
+        } else {
+            campoUnico.focus();
+        }
+    }
+
+    private async colarDoClipboard(): Promise<void> {
+        try {
+            const texto = await navigator.clipboard.readText();
+            if (!texto) {
+                this.exibirAviso("Nenhum conteúdo disponível para colar", TipoAviso.Erro);
+                return;
+            }
+            this.elementos.campoUnico.value = texto.trim();
+            this.exibirAviso("Conteúdo colado", TipoAviso.Info);
+        } catch {
+            this.exibirAviso("Não foi possível acessar a área de transferência", TipoAviso.Erro);
+        }
+    }
+
+    private validarUnico(): void {
+        const valor = this.elementos.campoUnico.value.trim();
+        if (!valor) {
+            this.exibirAviso("Informe um CNPJ para validar", TipoAviso.Erro);
+            return;
+        }
+
+        const resultado = this.validarCnpj(valor);
+        this.adicionarAoHistorico(resultado);
+        this.renderizarHistorico();
+
+        if (resultado.valido) {
+            this.exibirAviso("CNPJ válido", TipoAviso.Sucesso);
+        } else {
+            this.exibirAviso("CNPJ inválido", TipoAviso.Erro);
+        }
+    }
+
+    private validarEmMassa(): void {
+        const valor = this.elementos.campoMassa.value.trim();
+        if (!valor) {
+            this.exibirAviso("Informe ao menos um CNPJ para validar", TipoAviso.Erro);
+            return;
+        }
+
+        const entradas = valor
+            .split(",")
+            .map((parte) => parte.trim())
+            .filter((parte) => parte.length > 0);
+
+        if (entradas.length === 0) {
+            this.exibirAviso("Informe ao menos um CNPJ para validar", TipoAviso.Erro);
+            return;
+        }
+
+        if (entradas.length > 100) {
+            this.exibirAviso("Limite de 100 CNPJs por validação", TipoAviso.Erro);
+            return;
+        }
+
+        let validos = 0;
+        let invalidos = 0;
+
+        entradas.forEach((entrada) => {
+            const resultado = this.validarCnpj(entrada);
+            if (resultado.valido) {
+                validos++;
+            } else {
+                invalidos++;
+            }
+            this.adicionarAoHistorico(resultado);
+        });
+
+        this.renderizarHistorico();
+
+        if (invalidos === 0 && validos > 0) {
+            this.exibirAviso("CNPJ válido", TipoAviso.Sucesso);
+        } else {
+            this.exibirAviso("CNPJ inválido", TipoAviso.Erro);
+        }
+    }
+
+    private adicionarAoHistorico(resultado: ResultadoValidacao): void {
+        this.historico.unshift(resultado);
+        if (this.historico.length > this.limiteHistorico) {
+            this.historico.length = this.limiteHistorico;
+        }
+    }
+
+    private renderizarHistorico(): void {
+        const { listaHistorico, controleMascara } = this.elementos;
+        listaHistorico.innerHTML = "";
+
+        const aplicarMascara = controleMascara.checked;
+
+        this.historico.forEach((item) => {
+            const elemento = document.createElement("li");
+            elemento.className =
+                "flex items-center justify-between gap-3 rounded-xl bg-zinc-50/60 dark:bg-slate-900/60 px-3 py-2";
+
+            const texto = document.createElement("span");
+            texto.className = "text-sm font-semibold text-slate-600 dark:text-zinc-50 break-words";
+            texto.textContent = this.formatarParaExibicao(item.puro, aplicarMascara);
+
+            const status = document.createElement("span");
+            status.className = item.valido
+                ? "inline-flex items-center gap-2 rounded-full bg-emerald-500/90 px-3 py-1 text-xs font-semibold text-white"
+                : "inline-flex items-center gap-2 rounded-full bg-red-500/90 px-3 py-1 text-xs font-semibold text-white";
+            status.textContent = item.valido ? "✅ Válido" : "❌ Inválido";
+
+            elemento.append(texto, status);
+            listaHistorico.appendChild(elemento);
+        });
+
+        listaHistorico.scrollTop = 0;
+    }
+
+    private formatarParaExibicao(cnpj: string, aplicarMascara: boolean): string {
+        if (!aplicarMascara || cnpj.length !== 14) {
+            return cnpj;
+        }
+
+        return `${cnpj.slice(0, 2)}.${cnpj.slice(2, 5)}.${cnpj.slice(5, 8)}/${cnpj.slice(8, 12)}-${cnpj.slice(12)}`;
+    }
+
+    private validarCnpj(entrada: string): ResultadoValidacao {
+        const normalizado = entrada.toUpperCase();
+        const possuiCaracteresInvalidos = /[^0-9A-Z.\-/\s]/.test(normalizado);
+        const puro = normalizado.replace(/[.\-/\s]/g, "");
+
+        if (possuiCaracteresInvalidos) {
+            return { puro, valido: false };
+        }
+
+        if (puro.length !== 14) {
+            return { puro, valido: false };
+        }
+
+        if (!/^[0-9A-Z]{12}[0-9]{2}$/.test(puro)) {
+            return { puro, valido: false };
+        }
+
+        if (/^([0-9A-Z])\1{13}$/.test(puro)) {
+            return { puro, valido: false };
+        }
+
+        const corpo = puro.slice(0, 12);
+        const dvInformado = puro.slice(12);
+        const valores = Array.from(corpo).map((caractere) => this.converterCaractere(caractere));
+
+        const primeiroDV = this.calcularDigito(valores, PESOS_DIGITOS.primeiro);
+        const segundoDV = this.calcularDigito([...valores, primeiroDV], PESOS_DIGITOS.segundo);
+
+        const valido = primeiroDV === Number.parseInt(dvInformado[0] ?? "", 10)
+            && segundoDV === Number.parseInt(dvInformado[1] ?? "", 10);
+
+        return { puro, valido };
+    }
+
+    private converterCaractere(caractere: string): number {
+        const codigo = caractere.charCodeAt(0);
+        return codigo - 48;
+    }
+
+    private calcularDigito(valores: number[], pesos: number[]): number {
+        const soma = valores.reduce((acumulado, valorAtual, indice) => acumulado + valorAtual * (pesos[indice] ?? 0), 0);
+        const resto = soma % 11;
+        return resto < 2 ? 0 : 11 - resto;
+    }
+
+    private exibirAviso(mensagem: string, tipo: TipoAviso): void {
+        const { areaAviso } = this.elementos;
+        const classesBase =
+            "fixed bottom-4 right-4 min-w-[240px] max-w-[calc(100%-2rem)] rounded-lg px-4 py-3 text-sm shadow-2xl transition-all duration-200 ease-out";
+
+        areaAviso.textContent = mensagem;
+        areaAviso.className = `${classesBase} ${MAPA_CLASSES_TIPO_AVISO[tipo].join(" ")} ${ClasseAviso.OpacidadeOculta} ${ClasseAviso.TranslacaoOculta} ${ClasseAviso.PonteiroDesativado}`;
+
+        requestAnimationFrame(() => {
+            areaAviso.classList.remove(...CLASSES_AVISO_OCULTO);
+            areaAviso.classList.add(...CLASSES_AVISO_VISIVEL);
+        });
+
+        if (this.timeoutAviso !== undefined) {
+            window.clearTimeout(this.timeoutAviso);
+        }
+
+        this.timeoutAviso = window.setTimeout(() => {
+            areaAviso.classList.remove(...CLASSES_AVISO_VISIVEL);
+            areaAviso.classList.add(...CLASSES_AVISO_OCULTO);
+        }, IntervaloTemporizador.Aviso);
+    }
+}
+
+function obterElementoObrigatorio<T extends HTMLElement>(id: string): T {
+    const elemento = document.getElementById(id);
+    if (!elemento) {
+        throw new Error(`Elemento com id "${id}" não encontrado.`);
+    }
+    return elemento as T;
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    if (!document.getElementById("aviso-cookies")) {
+        document.body.insertAdjacentHTML("beforeend", htmlCookies);
+    }
+    inicializarAvisoDeCookies();
+
+    const elementos: ElementosValidador = {
+        campoUnico: obterElementoObrigatorio<HTMLInputElement>("campo-unico"),
+        campoMassa: obterElementoObrigatorio<HTMLTextAreaElement>("campo-massa"),
+        controleMascara: obterElementoObrigatorio<HTMLInputElement>("toggle-mascara-validator"),
+        controleMassa: obterElementoObrigatorio<HTMLInputElement>("toggle-massa"),
+        botaoValidarUnico: obterElementoObrigatorio<HTMLButtonElement>("botao-validar"),
+        botaoValidarMassa: obterElementoObrigatorio<HTMLButtonElement>("botao-validar-massa"),
+        listaHistorico: obterElementoObrigatorio<HTMLUListElement>("lista-historico-validacao"),
+        areaAviso: obterElementoObrigatorio<HTMLDivElement>("toast"),
+        botaoColar: obterElementoObrigatorio<HTMLButtonElement>("botao-colar"),
+    };
+
+    void new ValidadorCnpj(elementos);
+});
+
+export { };


### PR DESCRIPTION
## Summary
- add an educational page explaining the alphanumeric CNPJ structure, DV steps, and ASCII conversion table using the existing visual identity
- create a functional validator page with single and bulk validation modes, paste shortcut, and validation history badges aligned with current cards
- implement shared validation logic, toast handling, and cookie initialization for the new validator experience

## Testing
- npm run compilar
- npm run lintar

------
https://chatgpt.com/codex/tasks/task_b_68e5c5f9d79c832b8d60f13fef0c6793